### PR TITLE
Make volume sliders linear

### DIFF
--- a/autoloads/settings/user_defined_settings.gd
+++ b/autoloads/settings/user_defined_settings.gd
@@ -160,12 +160,12 @@ func _set_aa_mode_2d(mode_string: String):
 #region Audio Settings Callbacks
 
 func _set_audio_bus_volume(volume: float, bus: AudioBus):
-	volume = lerp(-20, 0, volume / 100.0)
+	volume /= 100.0
 	match bus:
-		AudioBus.MASTER: AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Master"), volume)
-		AudioBus.MUSIC: AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Music"), volume)
-		AudioBus.SFX: AudioServer.set_bus_volume_db(AudioServer.get_bus_index("SFX"), volume)
-		AudioBus.VOICE: AudioServer.set_bus_volume_db(AudioServer.get_bus_index("Voice"), volume)
+		AudioBus.MASTER: AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("Master"), volume)
+		AudioBus.MUSIC: AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("Music"), volume)
+		AudioBus.SFX: AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("SFX"), volume)
+		AudioBus.VOICE: AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("Voice"), volume)
 
 #endregion
 

--- a/autoloads/settings/user_defined_settings.gd
+++ b/autoloads/settings/user_defined_settings.gd
@@ -161,6 +161,7 @@ func _set_aa_mode_2d(mode_string: String):
 
 func _set_audio_bus_volume(volume: float, bus: AudioBus):
 	volume /= 100.0
+    volume = volume*volume # Quadratic curve for better control on low end
 	match bus:
 		AudioBus.MASTER: AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("Master"), volume)
 		AudioBus.MUSIC: AudioServer.set_bus_volume_linear(AudioServer.get_bus_index("Music"), volume)


### PR DESCRIPTION
`set_bus_volume_db` sets the volume in decibels, which are logarithmic rather than linear. Using `set_bus_volume_linear` allows setting the volume as linear value between 0 and 1. In particular, this fixes there still being sound when the volume slider is at 0%.